### PR TITLE
Allow static linking by use `EDITLINE_PATH` defineable

### DIFF
--- a/src/editline.odin
+++ b/src/editline.odin
@@ -3,8 +3,15 @@ package editline
 import "core:c"
 import "core:c/libc"
 
-// editline v1.17.1
-foreign import lib "system:editline"
+LIB_PATH :: #config(EDITLINE_PATH, "")
+
+when LIB_PATH == "" {
+    // editline v1.17.1
+    foreign import lib "system:editline"
+} else {
+    // user-supplied `libeditline.a`
+    foreign import lib { LIB_PATH }
+}
 
 Status :: enum c.int {
 	Done = 0, /* OK */


### PR DESCRIPTION
This commit adds a defineable value `EDITLINE_PATH` that can be used to point the library to `libeditline.a` for static linking. If `EDITLINE_PATH` is not defined, it maintains the original behavior of dynamically linking to the system-installed version of editline.